### PR TITLE
Fix duplicate DOM id in tab UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # easy-tabs
-a chrome extension to simplify tab management
-available at :- https://chrome.google.com/webstore/detail/gojbjpnihegjmfdbodmmcecpibgnoocb/publish-accepted?authuser=1
+A Chrome extension to simplify tab management. Updated to comply with Manifest
+V3 requirements.
+
+Available at:
+https://chrome.google.com/webstore/detail/gojbjpnihegjmfdbodmmcecpibgnoocb/publish-accepted?authuser=1

--- a/js/easy-tabs.js
+++ b/js/easy-tabs.js
@@ -18,12 +18,13 @@ var TabObject = function(tabDomain, tabUrl, tabTitle, tabID) {
 
 // on click visit-tab
 $('#accordion').on('click', 'span.visit-tab', function() {
-    chrome.tabs.update(parseInt($(this).attr('id')), { active: true, selected: true, highlighted: true });
+    chrome.tabs.update(parseInt($(this).attr('id')), { active: true });
 });
 
 // on click close-tab
 $('#accordion').on('click', 'span.close-tab', function() {
-    chrome.tabs.remove([parseInt($(this).attr('id'))]);
+    var tabId = parseInt($(this).attr('id').replace('close-', ''));
+    chrome.tabs.remove([tabId]);
     $(this).parent().parent().remove();
 });
 
@@ -32,7 +33,22 @@ function addTopList(domainName) {
 }
 
 function addSubLists(tabObject) {
-    $('#accordion').find('#panel-' + tabObject.tabDomain).append('<div id="collapse-' + tabObject.tabDomain + '" role="tabpanel" class="data-item" aria-labelledby="heading-' + tabObject.tabDomain + '"><div class="panel-body"><span class="visit-tab" id="' + tabObject.tabID + '">' + tabObject.tabTitle + '</span> &nbsp; <span class="glyphicon glyphicon-remove close-tab" aria-hidden="true" id="' + tabObject.tabID + '"></span></div></div>');
+    var subListID = 'collapse-' + tabObject.tabID;
+    $('#accordion')
+        .find('#panel-' + tabObject.tabDomain)
+        .append(
+            '<div id="' +
+                subListID +
+                '" role="tabpanel" class="data-item" aria-labelledby="heading-' +
+                tabObject.tabDomain +
+                '"><div class="panel-body"><span class="visit-tab" id="' +
+                tabObject.tabID +
+                '">' +
+                tabObject.tabTitle +
+                '</span> &nbsp; <span class="glyphicon glyphicon-remove close-tab" aria-hidden="true" id="close-' +
+                tabObject.tabID +
+                '"></span></div></div>'
+        );
 }
 
 // function generate tabs UI

--- a/manifest.json
+++ b/manifest.json
@@ -1,23 +1,18 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
 
     "name": "easy-tabs",
     "description": "a simple extension to simplify tab management",
     "version": "0.1",
 
-    "browser_action": {
-        "default_icon": "easy-tabs.png",
+    "action": {
+        "default_icon": {
+            "128": "easy-tabs.png"
+        },
         "default_popup": "easy-tabs.html",
         "default_title": "enter easy-tabs"
     },
     "permissions": [
-        "tabs",
-        "activeTab",
-        "background",
-        "clipboardRead",
-        "clipboardWrite",
-        "debugger",
-        "pageCapture",
-        "tabCapture"
+        "tabs"
     ]
 }


### PR DESCRIPTION
## Summary
- avoid assigning duplicate ids when listing multiple tabs from the same domain
- migrate to Manifest V3 and clean up unused permissions
- make tab closing logic use unique ids
- update docs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68565d6b6d08832d9ced147a8e8e0e6a