### PR TITLE
Fix open tabs display bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "easy-tabs",
+  "version": "0.1.0",
+  "description": "Easy Tabs Chrome extension",
+  "scripts": {
+    "test": "node test/extractDomain.test.js"
+  }
+}

--- a/test/extractDomain.test.js
+++ b/test/extractDomain.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const { extractDomain } = require('../js/easy-tabs.js');
+
+assert.strictEqual(extractDomain('https://example.com/path'), 'example.com');
+assert.strictEqual(extractDomain('chrome://extensions'), 'extensions');
+assert.strictEqual(extractDomain('about:blank'), null);
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- handle non-standard URLs when grouping open tabs
- avoid running DOM code during tests
- expose `extractDomain` for tests
- add basic test for domain extraction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856628785f8832dbddfb8eb5a7a2bf3