### PR TITLE
Fix deprecated call in easy-tabs

### DIFF
--- a/js/easy-tabs.js
+++ b/js/easy-tabs.js
@@ -102,7 +102,7 @@ function setDomainList(tabs) {
 
 if (typeof window !== 'undefined' && typeof chrome !== 'undefined') {
     $(document).ready(function() {
-        chrome.tabs.getAllInWindow(null, setDomainList);
+        chrome.tabs.query({}, setDomainList);
     });
 }
 


### PR DESCRIPTION
## Summary
- replace deprecated `chrome.tabs.getAllInWindow` with `chrome.tabs.query`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685663dbd7dc832d8121fa36e239e3d6