### PR TITLE
Add domain colors and icons

### DIFF
--- a/css/easy-tabs.css
+++ b/css/easy-tabs.css
@@ -17,7 +17,14 @@
 }
 
 .data-item {
-		padding: 2px 2px;
+                padding: 2px 2px;
     margin-bottom: -1px;
+}
+
+.domain-icon {
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+    vertical-align: text-bottom;
 }
 

--- a/js/easy-tabs.js
+++ b/js/easy-tabs.js
@@ -5,6 +5,19 @@
 var activeTabDomains = {};
 var domainRegex = /:\/\/(.[^/]+)/; // regex to get domains from URL
 
+function colorFromDomain(domain) {
+    var hash = 0;
+    for (var i = 0; i < domain.length; i++) {
+        hash = domain.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    var colour = '#';
+    for (var j = 0; j < 3; j++) {
+        var value = (hash >> (j * 8)) & 0xff;
+        colour += ('00' + value.toString(16)).substr(-2);
+    }
+    return colour;
+}
+
 function extractDomain(url) {
     var match = url.match(domainRegex);
     return match ? match[1] : null;
@@ -36,8 +49,21 @@ if (typeof window !== 'undefined' && typeof $ !== 'undefined') {
     });
 }
 
-function addTopList(domainName) {
-    $('#accordion').append('<div class="panel panel-default" id="panel-' + domainName + '"><div class="panel-heading" role="tab" id="heading-' + domainName + '"><h4 class="panel-title">' + inverseDomainMap[domainName] + '</h4></div></div>');
+function addTopList(domainName, iconUrl) {
+    var color = colorFromDomain(domainName);
+    $('#accordion').append(
+        '<div class="panel panel-default" id="panel-' +
+            domainName +
+            '"><div class="panel-heading" style="background-color:' +
+            color +
+            ';color:#fff;" role="tab" id="heading-' +
+            domainName +
+            '"><h4 class="panel-title"><img class="domain-icon" src="chrome://favicon/' +
+            iconUrl +
+            '"> ' +
+            inverseDomainMap[domainName] +
+            '</h4></div></div>'
+    );
 }
 
 function addSubLists(tabObject) {
@@ -63,7 +89,8 @@ function addSubLists(tabObject) {
 function generateTabsUI() {
     for (var domainName in activeTabDomains) {
         var domainsList = activeTabDomains[domainName];
-        addTopList(domainName);
+        var icon = domainsList[0].tabUrl;
+        addTopList(domainName, icon);
         for (var it in domainsList) {
             addSubLists(domainsList[it]);
         }


### PR DESCRIPTION
## Summary
- colorize tab groups by domain
- show tab favicons for quick identification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685665fbcaa8832d8f1896859d49df30