### PR TITLE
Fix favicon URL and add site search

### DIFF
--- a/css/easy-tabs.css
+++ b/css/easy-tabs.css
@@ -28,3 +28,7 @@
     vertical-align: text-bottom;
 }
 
+#searchBox {
+    margin-bottom: 8px;
+}
+

--- a/easy-tabs.html
+++ b/easy-tabs.html
@@ -24,6 +24,7 @@
 
 <body>
     <form class="">
+        <input type="text" id="searchBox" class="form-control" placeholder="Search sites..." />
         <span id="result"></span>
     </form>
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">

--- a/js/easy-tabs.js
+++ b/js/easy-tabs.js
@@ -5,6 +5,16 @@
 var activeTabDomains = {};
 var domainRegex = /:\/\/(.[^/]+)/; // regex to get domains from URL
 
+function sanitizeUrlForIcon(url) {
+    if (!url) return url;
+    try {
+        var u = new URL(url);
+        return u.origin === 'null' ? url.split('#')[0] : u.origin;
+    } catch (e) {
+        return url.split('#')[0];
+    }
+}
+
 function colorFromDomain(domain) {
     var hash = 0;
     for (var i = 0; i < domain.length; i++) {
@@ -46,6 +56,14 @@ if (typeof window !== 'undefined' && typeof $ !== 'undefined') {
         var tabId = parseInt($(this).attr('id').replace('close-', ''));
         chrome.tabs.remove([tabId]);
         $(this).parent().parent().remove();
+    });
+
+    $('#searchBox').on('input', function() {
+        var query = $(this).val().toLowerCase();
+        $('#accordion .panel').each(function() {
+            var text = $(this).find('.panel-title').text().toLowerCase();
+            $(this).toggle(text.indexOf(query) !== -1);
+        });
     });
 }
 
@@ -89,7 +107,7 @@ function addSubLists(tabObject) {
 function generateTabsUI() {
     for (var domainName in activeTabDomains) {
         var domainsList = activeTabDomains[domainName];
-        var icon = domainsList[0].tabUrl;
+        var icon = sanitizeUrlForIcon(domainsList[0].tabUrl);
         addTopList(domainName, icon);
         for (var it in domainsList) {
             addSubLists(domainsList[it]);
@@ -134,5 +152,5 @@ if (typeof window !== 'undefined' && typeof chrome !== 'undefined') {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { extractDomain };
+    module.exports = { extractDomain, sanitizeUrlForIcon };
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "description": "Easy Tabs Chrome extension",
   "scripts": {
-    "test": "node test/extractDomain.test.js"
+    "test": "node test/extractDomain.test.js && node test/sanitizeUrlForIcon.test.js"
   }
 }

--- a/test/sanitizeUrlForIcon.test.js
+++ b/test/sanitizeUrlForIcon.test.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const { sanitizeUrlForIcon } = require('../js/easy-tabs.js');
+
+assert.strictEqual(sanitizeUrlForIcon('https://example.com/path#frag'), 'https://example.com');
+assert.strictEqual(sanitizeUrlForIcon('chrome://extensions'), 'chrome://extensions');
+
+console.log('sanitizeUrlForIcon tests passed');


### PR DESCRIPTION
## Summary
- fix `chrome://favicon` URLs so they don't include fragments or invalid schemes
- add a search input for quickly filtering domains
- expose helper and tests for sanitizing URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856674fb420832daa42c99d96adfcd1