### PR TITLE
Improve gradient styling and CSS logos

### DIFF
--- a/css/easy-tabs.css
+++ b/css/easy-tabs.css
@@ -22,10 +22,17 @@
 }
 
 .domain-icon {
-    width: 16px;
-    height: 16px;
+    width: 20px;
+    height: 20px;
     margin-right: 4px;
     vertical-align: text-bottom;
+    border-radius: 4px;
+    display: inline-block;
+    text-align: center;
+    line-height: 20px;
+    font-size: 12px;
+    color: #fff;
+    font-weight: bold;
 }
 
 #searchBox {

--- a/js/easy-tabs.js
+++ b/js/easy-tabs.js
@@ -28,6 +28,25 @@ function colorFromDomain(domain) {
     return colour;
 }
 
+function lightenColor(color, percent) {
+    var num = parseInt(color.replace('#', ''), 16);
+    var amt = Math.round(2.55 * percent);
+    var R = (num >> 16) + amt;
+    var G = ((num >> 8) & 0x00ff) + amt;
+    var B = (num & 0x0000ff) + amt;
+    return (
+        '#' +
+        (
+            0x1000000 +
+            (R < 255 ? (R < 0 ? 0 : R) : 255) * 0x10000 +
+            (G < 255 ? (G < 0 ? 0 : G) : 255) * 0x100 +
+            (B < 255 ? (B < 0 ? 0 : B) : 255)
+        )
+            .toString(16)
+            .slice(1)
+    );
+}
+
 function extractDomain(url) {
     var match = url.match(domainRegex);
     return match ? match[1] : null;
@@ -67,18 +86,31 @@ if (typeof window !== 'undefined' && typeof $ !== 'undefined') {
     });
 }
 
-function addTopList(domainName, iconUrl) {
+function addTopList(domainName) {
     var color = colorFromDomain(domainName);
+    var colorLight = lightenColor(color, 30);
+    var firstLetter = inverseDomainMap[domainName].charAt(0).toUpperCase();
+    var angle = Math.floor(Math.random() * 360);
     $('#accordion').append(
         '<div class="panel panel-default" id="panel-' +
             domainName +
-            '"><div class="panel-heading" style="background-color:' +
+            '"><div class="panel-heading" style="background: linear-gradient(' +
+            angle +
+            'deg, ' +
             color +
-            ';color:#fff;" role="tab" id="heading-' +
+            ', ' +
+            colorLight +
+            ');color:#fff;" role="tab" id="heading-' +
             domainName +
-            '"><h4 class="panel-title"><img class="domain-icon" src="chrome://favicon/' +
-            iconUrl +
-            '"> ' +
+            '"><h4 class="panel-title"><span class="domain-icon" style="background: linear-gradient(' +
+            angle +
+            'deg, ' +
+            colorLight +
+            ', ' +
+            color +
+            ');">' +
+            firstLetter +
+            '</span> ' +
             inverseDomainMap[domainName] +
             '</h4></div></div>'
     );
@@ -107,8 +139,7 @@ function addSubLists(tabObject) {
 function generateTabsUI() {
     for (var domainName in activeTabDomains) {
         var domainsList = activeTabDomains[domainName];
-        var icon = sanitizeUrlForIcon(domainsList[0].tabUrl);
-        addTopList(domainName, icon);
+        addTopList(domainName);
         for (var it in domainsList) {
             addSubLists(domainsList[it]);
         }


### PR DESCRIPTION
## Summary
- lighten color based on domain and use gradient backgrounds
- generate CSS-based domain logos instead of favicon images
- style domain icon elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685674f06f48832dbf1dbec51f718cd0