### PR TITLE
Improve popup styling

### DIFF
--- a/css/easy-tabs.css
+++ b/css/easy-tabs.css
@@ -1,13 +1,35 @@
+@font-face {
+    font-family: "Roboto";
+    src: url("../fonts/roboto/Roboto-Regular.woff2") format("woff2"),
+         url("../fonts/roboto/Roboto-Regular.woff") format("woff"),
+         url("../fonts/roboto/Roboto-Regular.ttf") format("truetype");
+    font-weight: normal;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Roboto";
+    src: url("../fonts/roboto/Roboto-Bold.woff2") format("woff2"),
+         url("../fonts/roboto/Roboto-Bold.woff") format("woff"),
+         url("../fonts/roboto/Roboto-Bold.ttf") format("truetype");
+    font-weight: bold;
+    font-style: normal;
+}
+body {
+    font-family: "Roboto", "Segoe UI", "Lucida Grande", Tahoma, sans-serif;
+    background-color: #f8f9fa;
+    color: #212529;
+}
+
 #result {
     font-size: small;
 }
 
 #result .error {
-    color: red;
+    color: #d9534f;
 }
 
 #result .success {
-    color: green;
+    color: #5cb85c;
 }
 
 .visit-tab,
@@ -38,4 +60,9 @@
 #searchBox {
     margin-bottom: 8px;
 }
+.panel-heading {
+    border: none;
+    border-radius: 4px;
+}
+
 

--- a/easy-tabs.html
+++ b/easy-tabs.html
@@ -5,10 +5,12 @@
     <title>Easy-Tabs</title>
     <style>
     body {
-        font-family: "Segoe UI", "Lucida Grande", Tahoma, sans-serif;
+        font-family: 'Roboto', 'Segoe UI', 'Lucida Grande', Tahoma, sans-serif;
         font-size: 100%;
         height: 800px;
         width: 500px;
+        background-color: #f8f9fa;
+        color: #212529;
     }
 
     #status {


### PR DESCRIPTION
## Summary
- improve popup appearance with Roboto font
- use subtle background and text colors
- make panel headings clean

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856764ce098832daccc3edbf256c600