### PR TITLE
Add dark theme and rounded search box

### DIFF
--- a/css/easy-tabs.css
+++ b/css/easy-tabs.css
@@ -16,8 +16,8 @@
 }
 body {
     font-family: "Roboto", "Segoe UI", "Lucida Grande", Tahoma, sans-serif;
-    background-color: #f8f9fa;
-    color: #212529;
+    background-color: #121212;
+    color: #f8f9fa;
 }
 
 #result {
@@ -59,6 +59,13 @@ body {
 
 #searchBox {
     margin-bottom: 8px;
+    border-radius: 20px;
+    background-color: #212529;
+    border: 1px solid #495057;
+    color: #f8f9fa;
+}
+#searchBox::placeholder {
+    color: #adb5bd;
 }
 .panel-heading {
     border: none;
@@ -68,15 +75,15 @@ body {
 .panel {
     border: none;
     border-radius: 4px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5);
     margin-bottom: 8px;
-    background-color: #fff;
+    background-color: #1f1f1f;
 }
 
 .window-container {
-    background: #fff;
+    background: #1f1f1f;
     border-radius: 8px;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.5);
     padding: 8px;
     margin-bottom: 16px;
 }
@@ -85,8 +92,9 @@ body {
     font-size: 1.2em;
     margin-bottom: 8px;
     font-weight: bold;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid #444;
     padding-bottom: 4px;
+    color: #f8f9fa;
 }
 
 


### PR DESCRIPTION
## Summary
- apply dark theme colors across popup
- round search box boundaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68567e35a160832d83b2fc8b63a9b628